### PR TITLE
Add STL Viewer Shortcode

### DIFF
--- a/assets/css/stl-viewer.css
+++ b/assets/css/stl-viewer.css
@@ -1,0 +1,16 @@
+.stl-viewer {
+    width: 100%;
+    height: 500px;
+    background-color: #eee;
+    margin: 1rem 0;
+    border-radius: 8px;
+    overflow: hidden;
+    position: relative;
+    cursor: move;
+}
+
+.stl-viewer canvas {
+    display: block;
+    width: 100% !important;
+    height: 100% !important;
+}

--- a/assets/js/stl-viewer.js
+++ b/assets/js/stl-viewer.js
@@ -1,0 +1,91 @@
+import * as THREE from 'https://esm.sh/three@0.160.0';
+import { STLLoader } from 'https://esm.sh/three@0.160.0/examples/jsm/loaders/STLLoader.js';
+import { OrbitControls } from 'https://esm.sh/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+
+export function initSTLViewer(container) {
+    const url = container.getAttribute("data-src");
+    if (!url) return;
+
+    const width = container.clientWidth || 600;
+    const height = container.clientHeight || 400;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(container.getAttribute("data-bg-color") || "#eeeeee");
+
+    const camera = new THREE.PerspectiveCamera(35, width / height, 1, 1000);
+    camera.position.set(3, 3, 3);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setSize(width, height);
+    renderer.setPixelRatio(window.devicePixelRatio);
+    container.appendChild(renderer.domElement);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+
+    const loader = new STLLoader();
+    loader.load(url, (geometry) => {
+        const material = new THREE.MeshPhongMaterial({
+            color: container.getAttribute("data-model-color") || "#888888",
+            specular: 0x111111,
+            shininess: 200
+        });
+        const mesh = new THREE.Mesh(geometry, material);
+
+        geometry.computeBoundingBox();
+        const center = new THREE.Vector3();
+        geometry.boundingBox.getCenter(center);
+        mesh.position.sub(center);
+
+        scene.add(mesh);
+
+        const size = new THREE.Vector3();
+        geometry.boundingBox.getSize(size);
+        const maxDim = Math.max(size.x, size.y, size.z);
+        const distance = maxDim / (2 * Math.tan(Math.PI * camera.fov / 360));
+        camera.position.set(distance * 1.5, distance * 1.5, distance * 1.5);
+        camera.updateProjectionMatrix();
+
+        controls.target.set(0, 0, 0);
+        controls.update();
+    }, undefined, (error) => {
+        console.error('An error happened', error);
+        container.innerHTML = '<p style="color:red; padding: 20px;">Error loading STL file. Check console for details.</p>';
+    });
+
+    scene.add(new THREE.HemisphereLight(0xffffff, 0x111122));
+    const spotLight = new THREE.SpotLight(0xffffff, 1);
+    spotLight.position.set(20, 20, 10);
+    scene.add(spotLight);
+
+    function animate() {
+        requestAnimationFrame(animate);
+        controls.update();
+        renderer.render(scene, camera);
+    }
+    animate();
+
+    const resizeObserver = new ResizeObserver(() => {
+        if (container.clientWidth === 0 || container.clientHeight === 0) return;
+        camera.aspect = container.clientWidth / container.clientHeight;
+        camera.updateProjectionMatrix();
+        renderer.setSize(container.clientWidth, container.clientHeight);
+    });
+    resizeObserver.observe(container);
+}
+
+// Auto-initialize
+function autoInit() {
+    document.querySelectorAll(".stl-viewer").forEach(container => {
+        if (!container.getAttribute('data-initialized')) {
+            initSTLViewer(container);
+            container.setAttribute('data-initialized', 'true');
+        }
+    });
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', autoInit);
+} else {
+    autoInit();
+}

--- a/config.yaml
+++ b/config.yaml
@@ -89,5 +89,7 @@ module:
   mounts:
     - source: assets
       target: assets
+    - source: static
+      target: static
     - source: llms.txt
       target: static/llms.txt

--- a/layouts/shortcodes/stl.html
+++ b/layouts/shortcodes/stl.html
@@ -1,0 +1,21 @@
+{{ $src := .Get "src" }}
+{{ $width := .Get "width" | default "100%" }}
+{{ $height := .Get "height" | default "500px" }}
+{{ $bgColor := .Get "bg-color" | default "#eeeeee" }}
+{{ $modelColor := .Get "model-color" | default "#888888" }}
+
+{{ if not (.Page.Scratch.Get "stlViewerAssetsLoaded") }}
+    {{ $style := resources.Get "css/stl-viewer.css" | minify | fingerprint }}
+    <link rel="stylesheet" href="{{ $style.RelPermalink }}">
+
+    <script type="module" src="{{ (resources.Get "js/stl-viewer.js" | minify | fingerprint).RelPermalink }}"></script>
+
+    {{ .Page.Scratch.Set "stlViewerAssetsLoaded" true }}
+{{ end }}
+
+<div class="stl-viewer"
+     data-src="{{ $src }}"
+     data-bg-color="{{ $bgColor }}"
+     data-model-color="{{ $modelColor }}"
+     style="width: {{ $width }}; height: {{ $height }};">
+</div>


### PR DESCRIPTION
I have added a new Hugo shortcode `{{< stl src="..." >}}` that allows you to display STL files on your website. 

The implementation uses **Three.js** (loaded via ESM from esm.sh) to provide a high-performance 3D viewer. 

### Key Features:
- **Responsive:** The viewer automatically adjusts to the width of its container.
- **Auto-centering:** Models are automatically centered and the camera is positioned to fit the model in view.
- **Orbit Controls:** Users can rotate, zoom, and pan around the model.
- **Configurable:** You can customize the `width`, `height`, `bg-color`, and `model-color` via shortcode parameters.
- **Optimized:** CSS and JS assets are only loaded on pages that actually use the shortcode, and only once per page even if multiple models are present.

### Usage Example:
```markdown
{{< stl src="/models/my-awesome-print.stl" height="600px" model-color="#ff0000" >}}
```

I've organized the code into:
- `assets/js/stl-viewer.js`
- `assets/css/stl-viewer.css`
- `layouts/shortcodes/stl.html`

This ensures a clean separation of concerns and follows the existing project structure.

---
*PR created automatically by Jules for task [581228744944494910](https://jules.google.com/task/581228744944494910) started by @anshulpatel25*