### PR TITLE
Refactor sitemap to filter sections and pages

### DIFF
--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,0 +1,27 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Data.Pages }}
+    {{- $shouldInclude := false -}}
+    {{- if or (eq .Section "posts") (eq .Section "meetups") -}}
+      {{- $shouldInclude = true -}}
+    {{- else if in (slice "/about/" "/oss/" "/search/") .RelPermalink -}}
+      {{- $shouldInclude = true -}}
+    {{- end -}}
+
+    {{- if $shouldInclude -}}
+    <url>
+      <loc>{{ .Permalink }}</loc>
+      {{ if not .Lastmod.IsZero -}}
+      <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>
+      {{- end }}
+      {{ with .Sitemap.ChangeFreq -}}
+      <changefreq>{{ . }}</changefreq>
+      {{- end }}
+      {{ if ge .Sitemap.Priority 0.0 -}}
+      <priority>{{ .Sitemap.Priority }}</priority>
+      {{- end }}
+    </url>
+    {{- end -}}
+  {{ end }}
+</urlset>


### PR DESCRIPTION
I have refactored the sitemap to only include the requested sections and pages: About, Posts, Meetups, OSS, and Search. 

The implementation in `layouts/_default/sitemap.xml` ensures that:
1. The index pages for all requested sections are included.
2. All individual content pages within the 'posts' and 'meetups' sections are included to maintain SEO visibility for blog entries and meetup details.
3. Other pages (like the homepage, tags, or categories) are excluded from the sitemap.

I verified the changes by installing Hugo v0.140.1 and inspecting the generated `public/sitemap.xml`.

---
*PR created automatically by Jules for task [8092859160132410143](https://jules.google.com/task/8092859160132410143) started by @anshulpatel25*