### PR TITLE
Transition to Google Tag Manager

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,9 +10,8 @@ pagination:
 
 enableEmoji: true
 
-googleAnalytics: "G-62JLR4L8L8"
-
 params:
+  gtmId: "GTM-5T623Z3M"
   author: "Anshul Patel"
   description: "Anshul Patel's personal website"
   keywords: "geek, tinkerer, techie, blog, engineer"

--- a/layouts/partials/body/extensions.html
+++ b/layouts/partials/body/extensions.html
@@ -1,0 +1,6 @@
+{{ if .Site.Params.gtmId }}
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ .Site.Params.gtmId }}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+{{ end }}

--- a/layouts/partials/head/extensions.html
+++ b/layouts/partials/head/extensions.html
@@ -8,3 +8,13 @@
     })
 </script>
 {{ end }}
+
+{{ if .Site.Params.gtmId }}
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{ .Site.Params.gtmId }}');</script>
+<!-- End Google Tag Manager -->
+{{ end }}


### PR DESCRIPTION
I have transitioned the website from a built-in Google Analytics configuration to a Google Tag Manager (GTM) setup. 

The changes include:
1.  **Configuration Update:** Added `gtmId: "GTM-5T623Z3M"` to the `params` section of `config.yaml` and removed the old `googleAnalytics` property.
2.  **Head Script Injection:** Modified `layouts/partials/head/extensions.html` to include the primary GTM container script, dynamically using the ID from the configuration.
3.  **Body Script Injection:** Created `layouts/partials/body/extensions.html` to inject the GTM `noscript` tag immediately after the `<body>` tag opening, as per GTM best practices and theme extension guidelines.

I verified the changes by building the site locally with Hugo and ensuring both snippets are correctly rendered in the final HTML with the intended container ID.

---
*PR created automatically by Jules for task [14382702285613384072](https://jules.google.com/task/14382702285613384072) started by @anshulpatel25*