### PR TITLE
Refactor OSS Contributions page with improved UX/UI

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -14,3 +14,139 @@
   width: 100%;
   height: 100%;
 }
+
+/* OSS Cards Styling */
+.oss-container {
+  margin-top: 20px;
+}
+
+.oss-section-title {
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.oss-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.oss-card {
+  border: 1px solid var(--border-color, #e1e4e8);
+  border-radius: 6px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--bg-color, #ffffff);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  height: 100%;
+}
+
+body.colorscheme-dark .oss-card {
+  background-color: #212121;
+  border-color: #424242;
+}
+
+.oss-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+body.colorscheme-dark .oss-card:hover {
+  box-shadow: 0 4px 8px rgba(255,255,255,0.05);
+}
+
+.oss-card-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.oss-card-header i {
+  margin-top: 4px;
+  color: var(--primary-color, #0366d6);
+}
+
+body.colorscheme-dark .oss-card-header i {
+  color: #58a6ff;
+}
+
+.oss-card-header a {
+  text-decoration: none;
+  color: inherit;
+  flex: 1;
+}
+
+.oss-card-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.oss-card-header a:hover h3 {
+  color: var(--primary-color, #0366d6);
+  text-decoration: underline;
+}
+
+body.colorscheme-dark .oss-card-header a:hover h3 {
+  color: #58a6ff;
+}
+
+.oss-card-description {
+  margin: 0 0 12px 0;
+  font-size: 0.9rem;
+  color: var(--text-color-light, #586069);
+  flex-grow: 1;
+}
+
+body.colorscheme-dark .oss-card-description {
+  color: #8b949e;
+}
+
+.oss-card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.8rem;
+  color: var(--text-color-light, #586069);
+  margin-top: auto;
+}
+
+body.colorscheme-dark .oss-card-footer {
+  color: #8b949e;
+}
+
+.oss-repo {
+  font-family: monospace;
+}
+
+.oss-type {
+  padding: 2px 6px;
+  border-radius: 12px;
+  font-weight: 500;
+  font-size: 0.75rem;
+}
+
+.oss-type-pull-request {
+  background-color: #ddf4ff;
+  color: #0969da;
+}
+
+body.colorscheme-dark .oss-type-pull-request {
+  background-color: rgba(56,139,253,0.1);
+  color: #58a6ff;
+}
+
+.oss-type-issue {
+  background-color: #dafbe1;
+  color: #1a7f37;
+}
+
+body.colorscheme-dark .oss-type-issue {
+  background-color: rgba(46,160,67,0.1);
+  color: #3fb950;
+}

--- a/config.yaml
+++ b/config.yaml
@@ -88,3 +88,9 @@ module:
       target: static
     - source: llms.txt
       target: static/llms.txt
+    - source: data
+      target: data
+    - source: content
+      target: content
+    - source: layouts
+      target: layouts

--- a/content/oss/index.md
+++ b/content/oss/index.md
@@ -2,17 +2,4 @@
 title: Opensource Contributions
 ---
 
-- <https://github.com/anshulpatel25/yukti>
-- <https://github.com/anshulpatel25/termux-api-exporter>
-- <https://github.com/anshulpatel25/copilot-sdk-gateway>
-- <https://github.com/awsdocs/aws-systems-manager-user-guide/pull/125>
-- <https://github.com/awsdocs/amazon-ec2-auto-scaling-user-guide/pull/17>
-- <https://github.com/tektoncd/pipeline/issues/3721>
-- <https://github.com/mongodb/terraform-provider-mongodbatlas/issues/464>
-- <https://github.com/avelino/awesome-go/pull/2365>
-- <https://github.com/googleapis/google-resumable-media-python/issues/60>
-- <https://github.com/hashicorp/terraform-provider-google/issues/1952>
-- <https://github.com/edenhill/kcat/issues/73>
-- <https://github.com/philips-labs/terraform-aws-github-runner/issues/2287>
-- <https://github.com/python/mypy/issues/9223>
-- <https://github.com/keycloak/keycloak-admin-ui/issues/915>
+{{< oss >}}

--- a/data/oss.yaml
+++ b/data/oss.yaml
@@ -1,0 +1,59 @@
+projects:
+  - name: Yukti
+    url: https://github.com/anshulpatel25/yukti
+    description: Battery charging manager for rooted Android devices.
+    repo: anshulpatel25/yukti
+  - name: termux-api-exporter
+    url: https://github.com/anshulpatel25/termux-api-exporter
+    description: Prometheus exporter for termux-api services like battery, wifi, etc.
+    repo: anshulpatel25/termux-api-exporter
+  - name: copilot-sdk-gateway
+    url: https://github.com/anshulpatel25/copilot-sdk-gateway
+    description: OpenAI API compatible gateway for copilot-sdk.
+    repo: anshulpatel25/copilot-sdk-gateway
+
+contributions:
+  - title: Correction of Policy in the example
+    url: https://github.com/awsdocs/aws-systems-manager-user-guide/pull/125
+    repo: awsdocs/aws-systems-manager-user-guide
+    type: Pull Request
+  - title: Fix Incorrect Bracket Matching and Empty space characters on lifecycle-hooks.md page
+    url: https://github.com/awsdocs/amazon-ec2-auto-scaling-user-guide/pull/17
+    repo: awsdocs/amazon-ec2-auto-scaling-user-guide
+    type: Pull Request
+  - title: Feature request to detect whether executed TaskRun is part of finally section
+    url: https://github.com/tektoncd/pipeline/issues/3721
+    repo: tektoncd/pipeline
+    type: Issue
+  - title: mongodbatlas_private_endpoint and mongodbatlas_private_endpoint_interface_link gets re-created everytime
+    url: https://github.com/mongodb/terraform-provider-mongodbatlas/issues/464
+    repo: mongodb/terraform-provider-mongodbatlas
+    type: Issue
+  - title: Add go project layout
+    url: https://github.com/avelino/awesome-go/pull/2365
+    repo: avelino/awesome-go
+    type: Pull Request
+  - title: Support XML API for Resumable Upload
+    url: https://github.com/googleapis/google-resumable-media-python/issues/60
+    repo: googleapis/google-resumable-media-python
+    type: Issue
+  - title: google_cloudbuild_trigger should support disabled option
+    url: https://github.com/hashicorp/terraform-provider-google/issues/1952
+    repo: hashicorp/terraform-provider-google
+    type: Issue
+  - title: Update Readme to show how to use librdkafka configuration
+    url: https://github.com/edenhill/kcat/issues/73
+    repo: edenhill/kcat
+    type: Issue
+  - title: Issue #2287 in terraform-aws-github-runner
+    url: https://github.com/philips-labs/terraform-aws-github-runner/issues/2287
+    repo: philips-labs/terraform-aws-github-runner
+    type: Issue
+  - title: mypy doesn't raise error if boolean is used with Union inside the List
+    url: https://github.com/python/mypy/issues/9223
+    repo: python/mypy
+    type: Issue
+  - title: Issue #915 in keycloak-admin-ui
+    url: https://github.com/keycloak/keycloak-admin-ui/issues/915
+    repo: keycloak/keycloak-admin-ui
+    type: Issue

--- a/layouts/shortcodes/oss.html
+++ b/layouts/shortcodes/oss.html
@@ -1,0 +1,45 @@
+<div class="oss-container">
+  {{ $data := hugo.Data.oss }}
+
+  {{ if $data.projects }}
+  <h2 class="oss-section-title">My Projects</h2>
+  <div class="oss-grid">
+    {{ range $data.projects }}
+    <div class="oss-card">
+      <div class="oss-card-header">
+        <i class="fa fa-github" aria-hidden="true"></i>
+        <a href="{{ .url }}" target="_blank" rel="noopener noreferrer"><h3>{{ .name }}</h3></a>
+      </div>
+      <p class="oss-card-description">{{ .description }}</p>
+      <div class="oss-card-footer">
+        <span class="oss-repo">{{ .repo }}</span>
+      </div>
+    </div>
+    {{ end }}
+  </div>
+  {{ end }}
+
+  {{ if $data.contributions }}
+  <h2 class="oss-section-title">Contributions</h2>
+  <div class="oss-grid">
+    {{ range $data.contributions }}
+    <div class="oss-card">
+      <div class="oss-card-header">
+        {{ if eq .type "Pull Request" }}
+        <i class="fa fa-code-fork" aria-hidden="true"></i>
+        {{ else if eq .type "Issue" }}
+        <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+        {{ else }}
+        <i class="fa fa-github" aria-hidden="true"></i>
+        {{ end }}
+        <a href="{{ .url }}" target="_blank" rel="noopener noreferrer"><h3>{{ .title }}</h3></a>
+      </div>
+      <div class="oss-card-footer">
+        <span class="oss-repo">{{ .repo }}</span>
+        <span class="oss-type oss-type-{{ lower (replace .type " " "-") }}">{{ .type }}</span>
+      </div>
+    </div>
+    {{ end }}
+  </div>
+  {{ end }}
+</div>


### PR DESCRIPTION
This PR significantly improves the UI/UX of the Open Source contributions page by categorizing the raw list of GitHub URLs into clear, distinct sections (My Projects & Contributions). We mapped issues and pull requests to descriptive tags using a grid of UI cards, supporting both dark and light mode colorschemes cleanly with Fork Awesome icons.

---
*PR created automatically by Jules for task [12068003450423427440](https://jules.google.com/task/12068003450423427440) started by @anshulpatel25*